### PR TITLE
VK_LAYER_KHRONOS_validation

### DIFF
--- a/0-GettingStarted/0-Instance/Instance.cpp
+++ b/0-GettingStarted/0-Instance/Instance.cpp
@@ -45,7 +45,7 @@ bool CheckLayersSupport(const char** layers, int count)
 
 int main(int argc, char **argv)
 {
-	const char *instance_layers[] = { "VK_LAYER_LUNARG_standard_validation" };
+	const char *instance_layers[] = { "VK_LAYER_KHRONOS_validation" };
 	const char *instance_extensions[] = { "VK_EXT_debug_report" };
 
 	// Check to see if we have the layer requirments


### PR DESCRIPTION
Apparently VK_LAYER_LUNARG_standard_validation has deprecated and causes an error when I build it. This fixes it. (Based on this page https://vulkan.lunarg.com/doc/view/1.1.114.0/windows/validation_layers.html )